### PR TITLE
Correct off by one in calcid

### DIFF
--- a/abcde-musicbrainz-tool
+++ b/abcde-musicbrainz-tool
@@ -302,7 +302,7 @@ if ($command =~ m/^id/) {
     # Calculate MusicBrainz ID from disc offsets; see
     # https://musicbrainz.org/doc/DiscIDCalculation
 
-    if ($#discinfo < 5) {
+    if ($#discinfo < 4) {
 	print STDERR "Insufficient or missing discinfo data.\n";
 	exit(1);
     }


### PR DESCRIPTION
A single track CD (Jethro Tull, A Passion Play) invokes

  abcde-musicbrainz-tool --command calcid --discinfo 1 1 150 202360 0

$#discinfo is one less than the number of entries, 4, not 5.