### PR TITLE
Updated freedb URLs to gnudb

### DIFF
--- a/abcde
+++ b/abcde
@@ -3775,7 +3775,7 @@ post_encode ()
 # Currently three supported options ("musicbrainz", "cddb" for freedb.org and "cdtext")
 CDDBMETHOD=cddb,musicbrainz
 CDDBURL="http://gnudb.gnudb.org/~cddb/cddb.cgi"
-CDDBSUBMIT=freedb-submit@freedb.org
+CDDBSUBMIT=submit@gnudb.org
 CDDBPROTO=6
 HELLOINFO="$(whoami)@$(hostname)"
 CDDBCOPYLOCAL="n"

--- a/abcde
+++ b/abcde
@@ -3773,8 +3773,8 @@ post_encode ()
 
 # CDDB
 # Currently three supported options ("musicbrainz", "cddb" for freedb.org and "cdtext")
-CDDBMETHOD=musicbrainz
-CDDBURL="http://freedb.freedb.org/~cddb/cddb.cgi"
+CDDBMETHOD=cddb,musicbrainz
+CDDBURL="http://gnudb.gnudb.org/~cddb/cddb.cgi"
 CDDBSUBMIT=freedb-submit@freedb.org
 CDDBPROTO=6
 HELLOINFO="$(whoami)@$(hostname)"

--- a/abcde.conf
+++ b/abcde.conf
@@ -27,7 +27,7 @@ CDDBURL="http://gnudb.gnudb.org/~cddb/cddb.cgi"
 #HELLOINFO="`whoami`@`hostname`"
 
 # This controls the email address CDDB changes are submitted to.
-#CDDBSUBMIT=freedb-submit@freedb.org
+CDDBSUBMIT=submit@gnudb.org
 
 # The following options control whether or not fetched CDDB entries
 # are cached locally in $CDDBLOCALDIR

--- a/abcde.conf
+++ b/abcde.conf
@@ -10,12 +10,12 @@
 # "cdtext". Default is "musicbrainz", but all can be specified in a
 # comma delimited list to be tried sequentially. All the results will
 # be displayed ready for user choice.
-#CDDBMETHOD=musicbrainz
+CDDBMETHOD=cddb,musicbrainz
 
 # If you wish to use a different CDDB server, edit this line.
 # If you just wanted to use a proxy server, just set your http_proxy
 # environment variable - wget will use it correctly.
-#CDDBURL="http://freedb.freedb.org/~cddb/cddb.cgi"
+CDDBURL="http://gnudb.gnudb.org/~cddb/cddb.cgi"
 
 # The CDDB protocol level.
 # Right now 5 is latin1 output and 6 is UTF8 encoding.


### PR DESCRIPTION
Updated freedb URLs to change them to gnudb. This is due to [freedb being shutdown](https://blog.metabrainz.org/2018/09/18/freedb-gateway-end-of-life-notice-march-18-2019/).